### PR TITLE
Works properly with OpenLDAP directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,45 @@ example using Flask's
 and [blueprints](http://flask.pocoo.org/docs/blueprints/).
 
 
+OpenLDAP
+----------
+
+Add the ``LDAP`` instance to your code and depending on your OpenLDAP
+configuration, add the following at least LDAP_USER_OBJECT_FILTER and 
+LDAP_USER_OBJECT_FILTER.
+
+```python
+from flask import Flask
+from flask.ext.simpleldap import LDAP
+
+app = Flask(__name__)
+ldap = LDAP(app)
+
+# Base
+app.config['LDAP_REALM_NAME'] = 'OpenLDAP Authentication'
+app.config['LDAP_HOST'] = 'openldap.example.org'
+app.config['LDAP_BASE_DN'] = 'dc=users,dc=openldap,dc=org'
+app.config['LDAP_USERNAME'] = 'cn=user,ou=servauth-users,dc=users,dc=openldap,dc=org'
+app.config['LDAP_PASSWORD'] = 'password'
+
+# OpenLDAP 
+app.config['LDAP_OBJECTS_DN'] = 'dn'
+app.config['LDAP_OPENLDAP'] = True
+app.config['LDAP_USER_OBJECT_FILTER'] = '(&(objectclass=inetOrgPerson)(uid=%s))'
+
+# Groups
+app.config['LDAP_GROUP_MEMBERS_FIELD'] = "uniquemember"
+app.config['LDAP_GROUP_OBJECT_FILTER'] = "(&(objectclass=groupOfUniqueNames)(uniquemember=%s))"
+app.config['LDAP_GROUP_MEMBER_FILTER'] = "(&(cn=*)(objectclass=groupOfUniqueNames)(uniquemember=%s))"
+app.config['LDAP_GROUP_MEMBER_FILTER_FIELD'] = "cn"
+
+@app.route('/ldap')
+@ldap.login_required
+def ldap_protected():
+    return 'Success!'
+```
+
+
 Resources
 ---------
 

--- a/examples/basic_auth/app_oldap.py
+++ b/examples/basic_auth/app_oldap.py
@@ -1,0 +1,25 @@
+from flask import Flask, g, request, session, redirect, url_for
+from flask.ext.simpleldap import LDAP
+
+app = Flask(__name__)
+app.secret_key = 'dev key'
+app.debug = True
+
+app.config['LDAP_OPENLDAP'] = True
+app.config['LDAP_OBJECTS_DN'] = 'dn'
+app.config['LDAP_REALM_NAME'] = 'OpenLDAP Authentication'
+app.config['LDAP_HOST'] = 'openldap.example.org'
+app.config['LDAP_BASE_DN'] = 'dc=users,dc=openldap,dc=org'
+app.config['LDAP_USERNAME'] = 'cn=user,ou=servauth-users,dc=users,dc=openldap,dc=org'
+app.config['LDAP_PASSWORD'] = 'password'
+app.config['LDAP_USER_OBJECT_FILTER'] = '(&(objectclass=inetOrgPerson)(uid=%s))'
+
+ldap = LDAP(app)
+
+@app.route('/')
+@ldap.basic_auth_required
+def index():
+    return 'Welcome, {0}!'.format(g.ldap_username)
+
+if __name__ == '__main__':
+    app.run()

--- a/examples/groups/app_oldap.py
+++ b/examples/groups/app_oldap.py
@@ -5,10 +5,20 @@ app = Flask(__name__)
 app.secret_key = 'dev key'
 app.debug = True
 
-app.config['LDAP_HOST'] = 'ldap.example.org'
-app.config['LDAP_BASE_DN'] = 'OU=users,dc=example,dc=org'
-app.config['LDAP_USERNAME'] = 'CN=user,OU=Users,DC=example,DC=org'
+app.config['LDAP_OPENLDAP'] = True
+app.config['LDAP_OBJECTS_DN'] = 'dn'
+app.config['LDAP_REALM_NAME'] = 'OpenLDAP Authentication'
+app.config['LDAP_HOST'] = 'openldap.example.org'
+app.config['LDAP_BASE_DN'] = 'dc=users,dc=openldap,dc=org'
+app.config['LDAP_USERNAME'] = 'cn=user,ou=servauth-users,dc=users,dc=openldap,dc=org'
 app.config['LDAP_PASSWORD'] = 'password'
+app.config['LDAP_USER_OBJECT_FILTER'] = '(&(objectclass=inetOrgPerson)(uid=%s))'
+
+# Group configuration
+app.config['LDAP_GROUP_MEMBERS_FIELD'] = "uniquemember"
+app.config['LDAP_GROUP_OBJECT_FILTER'] = "(&(objectclass=groupOfUniqueNames)(uniquemember=%s))"
+app.config['LDAP_GROUP_MEMBER_FILTER'] = "(&(cn=*)(objectclass=groupOfUniqueNames)(uniquemember=%s))"
+app.config['LDAP_GROUP_MEMBER_FILTER_FIELD'] = "cn"
 
 ldap = LDAP(app)
 
@@ -49,7 +59,7 @@ def login():
 
 
 @app.route('/group')
-@ldap.group_required(groups=['Web Developers', 'QA'])
+@ldap.group_required(groups=['web-developers'])
 def group():
     return 'Group restricted page'
 

--- a/flask_simpleldap/__init__.py
+++ b/flask_simpleldap/__init__.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
-__all__ = ['LDAP']
-
 import re
 from functools import wraps
-
 import ldap
 import ldap.filter
 from flask import abort, current_app, g, make_response, redirect, url_for, \
     request
+
+__all__ = ['LDAP']
 
 try:
     from flask import _app_ctx_stack as stack
@@ -187,7 +186,8 @@ class LDAP(object):
                         if records:
                             return records[0][0]
                     else:
-                        if current_app.config['LDAP_OBJECTS_DN'] in records[0][1]:
+                        if current_app.config['LDAP_OBJECTS_DN'] \
+                                in records[0][1]:
                             dn = records[0][1][
                                 current_app.config['LDAP_OBJECTS_DN']]
                             return dn[0]
@@ -207,23 +207,28 @@ class LDAP(object):
         conn = self.bind
         try:
             if current_app.config['LDAP_OPENLDAP']:
-                fields = [str(current_app.config['LDAP_GROUP_MEMBER_FILTER_FIELD'])]
+                fields = \
+                    [str(current_app.config['LDAP_GROUP_MEMBER_FILTER_FIELD'])]
                 records = conn.search_s(
                     current_app.config['LDAP_BASE_DN'], ldap.SCOPE_SUBTREE,
-                    ldap.filter.filter_format(current_app.config['LDAP_GROUP_MEMBER_FILTER'],
-                                              (self.get_object_details(user, dn_only=True),)),
+                    ldap.filter.filter_format(
+                        current_app.config['LDAP_GROUP_MEMBER_FILTER'],
+                        (self.get_object_details(user, dn_only=True),)),
                     fields)
             else:
                 records = conn.search_s(
                     current_app.config['LDAP_BASE_DN'], ldap.SCOPE_SUBTREE,
                     ldap.filter.filter_format(
-                        current_app.config['LDAP_USER_OBJECT_FILTER'], (user,)),
+                        current_app.config['LDAP_USER_OBJECT_FILTER'],
+                        (user,)),
                     [current_app.config['LDAP_USER_GROUPS_FIELD']])
 
             conn.unbind_s()
             if records:
                 if current_app.config['LDAP_OPENLDAP']:
-                    groups = [record[1][current_app.config['LDAP_GROUP_MEMBER_FILTER_FIELD']][0] for
+                    group_member_filter = \
+                        current_app.config['LDAP_GROUP_MEMBER_FILTER_FIELD']
+                    groups = [record[1][group_member_filter][0] for
                               record in records]
                     return groups
                 else:

--- a/flask_simpleldap/__init__.py
+++ b/flask_simpleldap/__init__.py
@@ -142,7 +142,7 @@ class LDAP(object):
         """
 
         user_dn = self.get_object_details(user=username, dn_only=True)
-        print user_dn
+
         if user_dn is None:
             return
         try:


### PR DESCRIPTION
Works properly with OpenLDAP directories. Changes:    
- Three configuration directives have been added: LDAP_OPENLDAP,
     LDAP_GROUP_MEMBER_FILTER, LDAP_GROUP_MEMBER_FILTER_FIELD
- Examples: basic_auth/app_oldap.py and groups/app_oldap.py
- Updated README.md with a more instructions
- PEP8 check
    
    closes #16
    closes #15
    closes #14
