### PR TITLE
Fix set_option call to LDAP for SSL CERT

### DIFF
--- a/flask_simpleldap/__init__.py
+++ b/flask_simpleldap/__init__.py
@@ -67,9 +67,9 @@ class LDAP(object):
 
         if app.config['LDAP_REQUIRE_CERT']:
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,
-                            ldap.OPT_X_TLS_DEMAND,
-                            (ldap.OPT_X_TLS_CACERTFILE,
-                             current_app.config['LDAP_CERT_PATH']))
+                            ldap.OPT_X_TLS_DEMAND)
+            ldap.set_option(ldap.OPT_X_TLS_CACERTFILE,
+                             current_app.config['LDAP_CERT_PATH'])
 
         for option in ['USERNAME', 'PASSWORD', 'BASE_DN']:
             if app.config['LDAP_{0}'.format(option)] is None:


### PR DESCRIPTION
The set_option call to LDAP was not correct when configuring the LDAP SSL certificate