### PR TITLE
Replace pyldap with python-ldap in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask>=0.10.1',
-        'pyldap'
+        'python-ldap'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
pyldap is deprecated in favor of python-ldap