### PR TITLE
Referral chasing crash

### DIFF
--- a/flask_simpleldap/__init__.py
+++ b/flask_simpleldap/__init__.py
@@ -34,7 +34,6 @@ class LDAP(object):
         :param flask.Flask app: the application to configure for use with
            this :class:`~LDAP`
         """
-
         app.config.setdefault('LDAP_HOST', 'localhost')
         app.config.setdefault('LDAP_PORT', 389)
         app.config.setdefault('LDAP_SCHEMA', 'ldap')
@@ -163,7 +162,6 @@ class LDAP(object):
         :param bool dn_only: If we should only retrieve the object's
             distinguished name or not. Default: ``False``.
         """
-
         query = None
         fields = None
         if user is not None:
@@ -180,7 +178,6 @@ class LDAP(object):
         try:
             records = conn.search_s(current_app.config['LDAP_BASE_DN'],
                                     ldap.SCOPE_SUBTREE, query, fields)
-
             conn.unbind_s()
             result = {}
             if records:
@@ -194,9 +191,10 @@ class LDAP(object):
                             dn = records[0][1][
                                 current_app.config['LDAP_OBJECTS_DN']]
                             return dn[0]
-                for k, v in list(records[0][1].items()):
-                    result[k] = v
-                return result
+                if type(records[0][1]) == 'dict':
+                	for k, v in list(records[0][1].items()):
+                    		result[k] = v
+                	return result
         except ldap.LDAPError as e:
             raise LDAPException(self.error(e.args))
 
@@ -368,7 +366,6 @@ class LDAP(object):
             else:
                 req_username = request.authorization.username
                 req_password = request.authorization.password
-
             # Many LDAP servers will grant you anonymous access if you log in
             # with an empty password, even if you supply a non-anonymous user
             # ID, causing .bind_user() to return True. Therefore, only accept


### PR DESCRIPTION
Since a client can disable referral chasing - and it is very likely that they do in ldap3, otherwise anonymous binding could invalidate the query [(https://www.python-ldap.org/en/latest/faq.html), we should check if search_s from the python ldap library returns a list or a dictionary. In case the client in fact disabled chasing, search_s will return a list of referrals, and not the expected dict, so parsing it for all cases throws an attribute error on trying to access 'items()' on a list.