### PR TITLE
Bind ldap to current app

### DIFF
--- a/flask_simpleldap/__init__.py
+++ b/flask_simpleldap/__init__.py
@@ -76,6 +76,9 @@ class LDAP(object):
             if app.config['LDAP_{0}'.format(option)] is None:
                 raise LDAPException('LDAP_{0} cannot be None!'.format(option))
 
+        # Bind LDAP to app
+        app.ldap = self
+                
     @staticmethod
     def _set_custom_options(conn):
         options = current_app.config['LDAP_CUSTOM_OPTIONS']


### PR DESCRIPTION
It's often convenient to retrieve the LDAP object from current_app. This is done in flask_user and sqlalchemy for instance.