### PR TITLE
Fix regression in groups-related functions (".." vs b"..")

### DIFF
--- a/flask_simpleldap/__init__.py
+++ b/flask_simpleldap/__init__.py
@@ -232,8 +232,8 @@ class LDAP(object):
                 if current_app.config['LDAP_OPENLDAP']:
                     group_member_filter = \
                         current_app.config['LDAP_GROUP_MEMBER_FILTER_FIELD']
-                    groups = [record[1][group_member_filter][0] for
-                              record in records]
+                    groups = [record[1][group_member_filter][0].decode(
+                        'utf-8') for record in records]
                     return groups
                 else:
                     if current_app.config['LDAP_USER_GROUPS_FIELD'] in \
@@ -242,6 +242,7 @@ class LDAP(object):
                             current_app.config['LDAP_USER_GROUPS_FIELD']]
                         result = [re.findall(b'(?:cn=|CN=)(.*?),', group)[0]
                                   for group in groups]
+                        result = [r.decode('utf-8') for r in result]
                         return result
         except ldap.LDAPError as e:
             raise LDAPException(self.error(e.args))
@@ -266,6 +267,7 @@ class LDAP(object):
                         records[0][1]:
                     members = records[0][1][
                         current_app.config['LDAP_GROUP_MEMBERS_FIELD']]
+                    members = [m.decode('utf-8') for m in members]
                     return members
         except ldap.LDAPError as e:
             raise LDAPException(self.error(e.args))


### PR DESCRIPTION
(get_user_groups/get_group_members/group_required)

This was undone accidentally when removing support for Python2 in
https://github.com/admiralobvious/flask-simpleldap/commit/b2c0d10332d27db8b349753f89dceb7db520b7f2#diff-df961969fdc0fcec2f458e0fbb16eef9L238

Closes #63, #64.